### PR TITLE
Add initial `p2p` scaffolding

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,6 +8,7 @@ bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", default-featur
 tokio = { version = "1", default-features = false, optional = true, features = [
     "sync",
     "io-util",
+    "time",
     "net",
 ]}
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,14 +1,117 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use std::time::Duration;
+
+use bitcoin::p2p::ServiceFlags;
+
+pub mod tokio_ext;
+
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
+pub struct ProtocolVerison(pub u32);
+
+impl ProtocolVerison {
+    /// Support for relaying transactions by WTXID
+    pub const WTXID_RELAY: ProtocolVerison = ProtocolVerison(70016);
+    /// Invalid compact blocks are not a ban
+    pub const NO_BAN_CMPCT: ProtocolVerison = ProtocolVerison(70015);
+    /// Compact block message support
+    pub const CMPCT_BLOCKS: ProtocolVerison = ProtocolVerison(70014);
+    /// Support the `feefilter` message
+    pub const FEE_FILTER: ProtocolVerison = ProtocolVerison(70013);
+    /// Support `sendheaders` message to advertise new blocks with `header` messages
+    pub const SEND_HEADERS: ProtocolVerison = ProtocolVerison(70012);
+    /// Support NODE_BLOOM messages and do not support bloom filter messages if not set
+    pub const NODE_BLOOM: ProtocolVerison = ProtocolVerison(70011);
+    /// Support `reject` messages
+    pub const REJECT: ProtocolVerison = ProtocolVerison(70002);
+    /// Support bloom filter messages
+    pub const BLOOM_FILTERS: ProtocolVerison = ProtocolVerison(70001);
+    /// Support `mempool` messages
+    pub const MEMPOOL: ProtocolVerison = ProtocolVerison(60002);
+    /// Support `ping` and `pong` messages
+    pub const PING_PONG: ProtocolVerison = ProtocolVerison(60001);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Debug)]
+pub struct ConnectionBuilder {
+    offered_services: ServiceFlags,
+    their_services: ServiceFlags,
+    our_version: ProtocolVerison,
+    their_version: ProtocolVerison,
+    they_sent_wtxid_relay: bool,
+    they_sent_cmpct_block: bool,
+    they_sent_send_headers: bool,
+    they_sent_addrv2: bool,
+    handshake_timeout: Duration,
+    connection_timeout: Duration,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl ConnectionBuilder {
+    fn new() -> Self {
+        Self {
+            offered_services: ServiceFlags::NONE,
+            their_services: ServiceFlags::NONE,
+            our_version: ProtocolVerison::WTXID_RELAY,
+            their_version: ProtocolVerison::WTXID_RELAY,
+            they_sent_wtxid_relay: false,
+            they_sent_cmpct_block: false,
+            they_sent_addrv2: false,
+            they_sent_send_headers: false,
+            handshake_timeout: HANDSHAKE_TIMEOUT,
+            connection_timeout: CONNECTION_TIMEOUT,
+        }
+    }
+
+    fn offered_services(self, us: ServiceFlags) -> Self {
+        Self {
+            offered_services: us,
+            ..self
+        }
+    }
+
+    fn their_services_required(self, them: ServiceFlags) -> Self {
+        Self {
+            their_services: them,
+            ..self
+        }
+    }
+
+    fn downgrade_to_version(self, us: ProtocolVerison) -> Self {
+        Self {
+            our_version: us,
+            ..self
+        }
+    }
+
+    fn accept_minimum_version(self, them: ProtocolVerison) -> Self {
+        Self {
+            their_version: them,
+            ..self
+        }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum HandshakeError {
+    TooLowVersion(ProtocolVerison),
+    UnsupportedFeature,
+    TimedOut,
+}
+
+impl std::fmt::Display for HandshakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimedOut => write!(f, "the handshake timed out."),
+            Self::UnsupportedFeature => write!(
+                f,
+                "a feature we require is not supported by the connection."
+            ),
+            Self::TooLowVersion(version) => {
+                write!(f, "the remote peer had a too-low version: {}", version.0)
+            }
+        }
+    }
+}
+
+impl std::error::Error for HandshakeError {}

--- a/p2p/src/tokio_ext.rs
+++ b/p2p/src/tokio_ext.rs
@@ -1,0 +1,45 @@
+use::std::fmt::{Debug, Display};
+use std::net::SocketAddr;
+
+use tokio::{io, net::TcpStream, time::timeout};
+
+use crate::{ConnectionBuilder, HandshakeError};
+
+pub trait ConnectionTokioExt {
+    type Error: Debug + Display + Send + Sync + std::error::Error;
+
+    async fn open_connection(self, to: impl Into<SocketAddr>) -> Result<TcpStream, Self::Error>;
+}
+
+impl ConnectionTokioExt for ConnectionBuilder {
+    type Error = TokioConnectionError;
+
+    async fn open_connection(self, to: impl Into<SocketAddr>) -> Result<TcpStream, Self::Error> {
+        let socket_addr = to.into();
+        let tcp_stream = timeout(self.connection_timeout, TcpStream::connect(socket_addr)).await.map_err(|_| TokioConnectionError::Protocol(HandshakeError::TimedOut))??;
+        Ok(tcp_stream)
+    }
+}
+
+#[derive(Debug)]
+pub enum TokioConnectionError {
+    Io(io::Error),
+    Protocol(HandshakeError),
+}
+
+impl From<io::Error> for TokioConnectionError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl Display for TokioConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(io) => write!(f, "unexpected io error: {io}"),
+            Self::Protocol(proto) => write!(f, "protocol negotiation error: {proto}"),
+        }
+    }
+}
+
+impl std::error::Error for TokioConnectionError {};


### PR DESCRIPTION
Adds a `ConnectionBuilder` to configure a connection to user preferences that can be extended by IO implementations in `std` and `tokio`. Also adds a `ProtocolVersion` structure.