### PR TITLE
ci: Remove platform matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,7 @@ jobs:
       - run: just check
   # Build and test the code across platforms.
   test:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3


### PR DESCRIPTION
`bitcoind` regression tests need only run on Linux