### PR TITLE
docs: add warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SwiftSync
 
+:warning::construction: This project is still under construction and expected to change significantly. Use at your own risk :construction::warning:
+
 This repository is a collection of crates related to a SwiftSync node implementation. Some crates will be SwiftSync-specific, while others may have broader use cases.
 
 `accumulator`: A hash-based SwiftSync accumulator used to add and subtrack elements from a set.


### PR DESCRIPTION
add small warning to indicate to users we are still hacking on this and nothing in here is expected to be stable/usable/etc