### PR TITLE
Remove `bitcoin` from `network`

### DIFF
--- a/accumulator/Cargo.toml
+++ b/accumulator/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 bitcoin = { workspace = true } 
 
 [dev-dependencies]
+bitcoin = { workspace = true, default-features = true } 
 rusqlite = { version = "0.36.0", features = ["bundled"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bitcoin = { workspace = true, features = ["rand-std"] } 
 tokio = { version = "1", default-features = false, optional = true, features = [
     "io-util",
     "net",
@@ -14,5 +13,5 @@ tokio = { version = "1", default-features = false, optional = true, features = [
 tokio = { version = "1", default-features = false, features = ["full"] }
 
 [features]
-default = ["tokio"]
+default = []
 tokio = ["dep:tokio"]

--- a/network/src/dns.rs
+++ b/network/src/dns.rs
@@ -4,10 +4,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use bitcoin::secp256k1::rand::RngCore;
-use bitcoin::secp256k1::rand::thread_rng;
-
-use crate::encode_qname;
+use crate::{encode_qname, rand_bytes};
 
 const CLOUDFLARE: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 53);
 
@@ -43,9 +40,7 @@ pub struct DnsQuery {
 impl DnsQuery {
     pub fn new(seed: &str, dns_resolver: SocketAddr) -> Self {
         // Build a header
-        let mut rng = thread_rng();
-        let mut message_id = [0, 0];
-        rng.fill_bytes(&mut message_id);
+        let message_id = rand_bytes();
         let mut message = message_id.to_vec();
         message.extend(RECURSIVE_FLAGS);
         message.push(0x00); // QDCOUNT
@@ -63,9 +58,7 @@ impl DnsQuery {
     }
 
     pub fn new_cloudflare(seed: &str) -> Self {
-        let mut rng = thread_rng();
-        let mut message_id = [0, 0];
-        rng.fill_bytes(&mut message_id);
+        let message_id = rand_bytes();
         let mut message = message_id.to_vec();
         message.extend(RECURSIVE_FLAGS);
         message.push(0x00); // QDCOUNT

--- a/network/tests/test.rs
+++ b/network/tests/test.rs
@@ -3,6 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use peers::dns::DnsQuery;
 
 #[tokio::test]
+#[cfg(feature = "tokio")]
 async fn test_tokio_dns_ext() {
     use peers::dns::TokioDnsExt;
     let resolver = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(46, 166, 189, 67)), 53);


### PR DESCRIPTION
The plan for `network` is to hold networking related tools that do not have anything to do with bitcoin itself, but are very useful for bitcoin in general. Removes `bitcoin` as a dependency and makes `tokio` optional.