### PR TITLE
Remove `bitcoin` from `hintfile`

### DIFF
--- a/hintfile/Cargo.toml
+++ b/hintfile/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bitcoin = { workspace = true }
 kernel = { workspace = true }
 
 [[bin]]

--- a/node/src/bin/ibd.rs
+++ b/node/src/bin/ibd.rs
@@ -5,7 +5,7 @@ use std::{
     time::Instant,
 };
 
-use bitcoin::Network;
+use bitcoin::{consensus, BlockHash, Network};
 use hintfile::Hints;
 use kernel::{ChainType, ChainstateManager, ChainstateManagerOptions, ContextBuilder};
 
@@ -33,7 +33,8 @@ fn main() {
     elapsed_time(hintfile_start_time);
     let block_file_path = Path::new(BLOCK_FILE_PATH);
     std::fs::create_dir(block_file_path).expect("could not create block file directory");
-    let stop_hash = hints.stop_hash();
+    let stop_hash =
+        consensus::deserialize::<BlockHash>(&hints.stop_hash()).expect("stop hash is not valid");
     tracing::info!("Assume valid hash: {stop_hash}");
     tracing::info!("Finding peers with DNS");
     let dns_start_time = Instant::now();

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -17,7 +17,7 @@ use bitcoin::{
     key::rand::{seq::SliceRandom, thread_rng},
     script::ScriptExt,
     transaction::TransactionExt,
-    BlockHash, BlockHeight, Network, OutPoint,
+    BlockHash, Network, OutPoint,
 };
 use hintfile::Hints;
 use kernel::ChainstateManager;
@@ -202,10 +202,10 @@ pub fn get_blocks_for_range(
                     let kernal_hash: kernel::BlockHash = kernel::BlockHash {
                         hash: hash.to_byte_array(),
                     };
-                    let height = chain
+                    let block_index = chain
                         .block_index_by_hash(kernal_hash)
                         .expect("header is in best chain.");
-                    let block_height = BlockHeight::from_u32(height.height().unsigned_abs());
+                    let block_height = block_index.height().unsigned_abs();
                     let unspent_indexes: HashSet<u64> =
                         hints.get_block_offsets(block_height).into_iter().collect();
                     // tracing::info!("{task_id} -> {block_height}:{hash}");


### PR DESCRIPTION
Turns out the `BlockHeight` type is not very ergonomic to worth with. The `hintfile` does not depend on many types from `bitcoin`, so I remove them here and add type aliases.